### PR TITLE
Adding missing Conciliation cross

### DIFF
--- a/js/markers.js
+++ b/js/markers.js
@@ -6500,6 +6500,11 @@ Spade to bury Henry's parents
 "group": "camp",
 "icon": "camp",
 "coords": [2280.542969,3793.338623],
-},	
-
+},
+{	
+"name": "<span data-i18n='conciliation_cross'>Conciliation Cross</span>",
+"group": "conciliation_cross",
+"icon": "conciliation_cross",
+"coords": [1378,3676],
+},
 ]


### PR DESCRIPTION
Missing cross between Skallitz and Pribyslavitz

Ingame map :
![image](https://github.com/user-attachments/assets/515393a5-4476-49eb-9e3f-18cd0977ce5b)

Browser map (added user marker to get coords):
![image](https://github.com/user-attachments/assets/223897a9-21a6-4949-9d37-11c2b7cc584f)
